### PR TITLE
It can't work for my mac if you remove -noinput

### DIFF
--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 
 main(_) ->
     App = "mad",
-    EmuArgs = "-noshell",
+    EmuArgs = "-noshell -noinput",
     Files = files(),
     escript:create(App, [shebang, {comment, ""}, {emu_args, EmuArgs}, {archive, Files, []}]),
     ok = file:change_mode(App, 8#764).


### PR DESCRIPTION
follow is the error report before:

=ERROR REPORT==== 17-Aug-2014::08:58:16 ===
driver_select(0x000000001a9c00a0, 0, ERL_DRV_READ ERL_DRV_USE, 1) by tty_sl (tty_sl -c -e) driver #Port<0.63512> stealing control of fd=0 from input driver fd (0/1) #Port<0.420> 
