### PR TITLE
mad_repl: user_drv wants user to be registered, but that's not what we want

### DIFF
--- a/src/mad_repl.erl
+++ b/src/mad_repl.erl
@@ -69,6 +69,9 @@ main(Params) ->
     io:format("Applications: ~p\n\r",[applist()]),
     Config = load_config(),
 
+    % trick user_drv into starting group.erl's output handler
+    unregister(user),
+
     case os:type() of
          {win32,nt} -> shell:start();
                   _ -> user_drv:start() end,


### PR DESCRIPTION
after -noshell -noinput
