### PR TITLE
Add support for rebar deps that don't specify hash

### DIFF
--- a/src/mad_deps.erl
+++ b/src/mad_deps.erl
@@ -20,7 +20,9 @@ fetch(Cwd, Config, ConfigFile, [H|T]) ->
                          V={_, _, _} ->
                              V;
                          {_Cmd, _Url, _Co, _} ->
-                             {_Cmd, _Url, _Co}
+                             {_Cmd, _Url, _Co};
+                         {_Cmd, _Url} ->
+                             {_Cmd, _Url, "master"}
                      end,
     Cmd1 = atom_to_list(Cmd),
     Cache = mad_utils:get_value(cache, Config, deps_fetch),


### PR DESCRIPTION
Here's an example of such a dependency in the wild: (rebar indeed supports it)
https://github.com/processone/cache_tab/blob/master/rebar.config#L3
