### PR TITLE
Fixed loading of .app config files from ETS filesystem.

### DIFF
--- a/src/provision/mad_repl.erl
+++ b/src/provision/mad_repl.erl
@@ -164,7 +164,7 @@ load_config(A) when is_list(A) ->
     case file:read_file(Name) of
          {ok,Bin} -> parse(binary_to_list(Bin));
          {error,_} -> case ets:lookup(filesystem,AppFile) of
-                          [{Name,Bin}] -> parse(binary_to_list(Bin));
+                          [{AppFile,Bin}] -> parse(binary_to_list(Bin));
                           _ -> [] end end.
 
 parse(String) ->


### PR DESCRIPTION
When single-file bundle (escript) built by MAD is deployed, it cannot find apps' configuration file(s) is the ETS filesystem (see comments):

```erlang
load_config(A) when is_list(A) ->
    AppFile = A ++".app",
    Name = wildcards(["{apps,deps}/*/ebin/"++AppFile,"ebin/"++AppFile]), % here Name will be = []
    case file:read_file(Name) of % there are no files except escript bundle, failed
         {ok,Bin} -> parse(binary_to_list(Bin));
         {error,_} -> case ets:lookup(filesystem,AppFile) of % OK, found .app file is the ETS...
                          [{Name,Bin}] -> parse(binary_to_list(Bin)); % ...but pattern matching failed
                          _ -> [] end end.
```