### PR TITLE
Configurable escript emu_args

### DIFF
--- a/escript.config
+++ b/escript.config
@@ -1,0 +1,7 @@
+% MAD default:
+%
+{ emu_args, "+pc unicode" }.
+
+% Daemonizable escript:
+%
+% { emu_args, "+pc unicode -detached" }.

--- a/src/package/mad_escript.erl
+++ b/src/package/mad_escript.erl
@@ -5,7 +5,11 @@
 main(N) ->
     App = filename:basename(case N of [] -> mad_utils:cwd(); E -> E end),
     mad_resolve:main([]),
-    EmuArgs = "+pc unicode",
+    DefaultEmuArgs = "+pc unicode",
+    EmuArgs = case file:consult( "escript.config" ) of
+       { ok, Terms } -> proplists:get_value( emu_args, Terms, DefaultEmuArgs );
+       _ -> DefaultEmuArgs
+    end,
     Files = static() ++ beams(fun filename:basename/1, fun read_file/1) ++ overlay(),
 %   [ io:format("Escript: ~ts~n",[File]) || { File, _ } <- Files ],
     escript:create(App,[shebang,{comment,""},{emu_args,EmuArgs},{archive,Files,[memory]}]),


### PR DESCRIPTION
MAD inserts the following hard-coded emu_args to the escript bundle: "+pc unicode".
It will be useful to allow the user to specify emu_args in a configuration file (see added 'escript.config').
