### PR TITLE
Updated dependency for "n2o" library.

### DIFF
--- a/priv/web/rebar.config
+++ b/priv/web/rebar.config
@@ -4,7 +4,7 @@
     {erlydtl,".*", {git, "git://github.com/voxoz/erlydtl",      []}},
     {active, ".*", {git, "git://github.com/synrc/active",       []}},
     {nitro,  ".*", {git, "git://github.com/synrc/nitro",        []}},
-    {n2o,    ".*", {git, "git://github.com/synrc/mqtt",         []}},
+    {n2o,    ".*", {git, "git://github.com/synrc/n2o",          []}},
     {kvs,    ".*", {git, "git://github.com/synrc/kvs",          []}}
 ]}.
 {erlydtl_opts, [


### PR DESCRIPTION
Since "mqtt" repository contain version 5.11 it's better to update it to most recent "n2o" repository.