### PR TITLE
Fix for 'attach' script

### DIFF
--- a/priv/systools/attach
+++ b/priv/systools/attach
@@ -1,3 +1,3 @@
 SCRIPT="$(dirname "$0")"
 ROOT="$(cd "$SCRIPT/.." && pwd)"
-"$ROOT/bin/to_erl" "$ROOT/log" "$ROOT/log"
+"$ROOT/bin/to_erl" "$ROOT/log/" "$ROOT/log/"


### PR DESCRIPTION
Without slash after 'log' script fail to connect with error "No running Erlang on pipe /XXX/log: No such file or directory" . Adding slash like in 'daemon' script - solve issue.